### PR TITLE
Update wrapping.rst

### DIFF
--- a/docs/usage/system_backend/wrapping.rst
+++ b/docs/usage/system_backend/wrapping.rst
@@ -42,6 +42,17 @@ Examples
     )
     print('Unwrapped approle role token secret id accessor: "%s"' % unwrap_response['data']['secret_id_accessor'])
 
+.. testcode:: sys_wrapping
+
+    import hvac
+
+    client = hvac.Client(url='https://127.0.0.1:8200')
+    client.token = "s.xxxxxxxxxxxxxxxxxxxxxx"
+
+    # When authenticating with just the wrapping token, should not pass token into unwrap call
+    unwrap_response = client.sys.unwrap()
+    print('Unwrapped approle role token secret id accessor: "%s"' % unwrap_response['data']['secret_id_accessor'])
+
 Example output:
 
 .. testoutput:: sys_wrapping


### PR DESCRIPTION
Provide example of using unwrap with just the wrapping token. Previous example is non-functional unless already authenticated.